### PR TITLE
Use thread for polling laser status

### DIFF
--- a/devices/ipg_ylr_laser_controller.py
+++ b/devices/ipg_ylr_laser_controller.py
@@ -348,12 +348,17 @@ class IPGYLRLaserController:
     def output_power(self) -> Optional[float]:
         command = "ROP"
         res = self._send_receive(command)
-        if res is None:
-            return None
         try:
-            return float(res.split(": ")[1])
-        except (IndexError, ValueError) as e:
-            logging.error(f"Failed to parse output power: {res} ({e})")
+            val = res.split(": ")[1]
+        except IndexError as e:
+            logging.error(f"Failed to parse output power response: {res} ({e})")
+            return None
+        if val == "Off":
+            return 0.0
+        try:
+            return float(val)
+        except (TypeError, ValueError) as e:
+            logging.error(f"Failed to read output power value: {res} ({e})")
             return None
     
 

--- a/widgets/ipg_fiber_laser_widget.py
+++ b/widgets/ipg_fiber_laser_widget.py
@@ -2,7 +2,7 @@ from PyQt6.QtWidgets import (
     QGroupBox, QPushButton, QLabel, QVBoxLayout, QHBoxLayout,
     QDoubleSpinBox, QMessageBox, QLineEdit, QFormLayout
 )
-from PyQt6.QtCore import QTimer
+from PyQt6.QtCore import QTimer, QThread, pyqtSignal
 from devices.ipg_ylr_laser_controller import IPGYLRLaserController, LaserStatus
 import logging
 
@@ -206,3 +206,24 @@ class LaserControlWidget(QGroupBox):
         if status.high_average_power:
             message_list.append("High Average Power")
         return "\n\t".join(message_list) if message_list else "Idle"
+
+
+class LaserPollingThread(QThread):
+    
+    status_updated = pyqtSignal(dict) # dict type data is given to LaserControlWidget
+
+    def __init__(self, controller, interval=0.5, parent=None):
+        super().__init__(parent)
+        self.controller = controller
+        self.interval = interval
+        self._running = True
+    
+
+    def run(self):
+        while self._running:
+            pass
+
+    
+    def stop(self):
+        self._running = False
+        self.wait()

--- a/widgets/ipg_fiber_laser_widget.py
+++ b/widgets/ipg_fiber_laser_widget.py
@@ -174,7 +174,9 @@ class LaserControlWidget(QGroupBox):
 
 
     def clear_status_display(self):
+        self.setpoint_spin.blockSignals(True) 
         self.setpoint_spin.setValue(0)
+        self.setpoint_spin.blockSignals(False) 
         self.power_label.setText("Output Power: --- W")
         self.temp_label.setText("Temp: --- °C")
         self.laser_status_display.setText("Laser Status: ---")


### PR DESCRIPTION
New polling thread is introduced into LaserControlWidget class to avoid freezing of main GUI.

Add missing laser output power label.